### PR TITLE
geminipy: add ticker method to get last trade

### DIFF
--- a/geminipy/__init__.py
+++ b/geminipy/__init__.py
@@ -84,6 +84,30 @@ class Geminipy(object):
 
         return requests.get(url, params)
 
+    def ticker(self, symbol='btcusd'):
+      """
+      Retrieve information about recent trading activity for the symbol
+
+      Response:
+      bid    -- decimal The highest bid currently available
+      asks   -- decimal The lowest ask currently available
+      last   -- decimal The price of the last executed trade
+      volume -- Information about the 24 hour volume on the exchange. It contains
+                either of these values:
+		-------------------------------------------------------------------------------------------------------
+		|      Field                  |         Type         | Description
+		-------------------------------------------------------------------------------------------------------
+		|      timestamp              |     timestampms      | The end of the 24-hour period over
+		|                             |                      | which volume was measured
+		-------------------------------------------------------------------------------------------------------
+		| (price symbol, e.g. "USD")  |       decimal        |  The volume denominated in the price currency
+		-------------------------------------------------------------------------------------------------------
+		|(quantity symbol, e.g. "BTC")|       decimal        | The volume denominated in the quantity currency
+		-------------------------------------------------------------------------------------------------------
+      """
+      url = self.base_url + '/v1/pubticker/' + symbol
+      return requests.get(url)
+
     # authenticated requests
     def new_order(self, amount, price, side, client_order_id=None,
                   symbol='btcusd', type='exchange limit'):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setup(
     name='geminipy',
-    version='0.0.1',
+    version='0.0.2',
     packages=['geminipy'],
     url='https://github.com/geminipy/geminipy',
     license='GNU GPL',


### PR DESCRIPTION
Fixes #1

Can now query for the last trade on Gemini
as per https://docs.gemini.com/rest-api/#ticker

```python
>>> import os
>>> from geminipy import Geminipy
>>> g = Geminipy(os.environ['GEMINI_API_KEY'], os.environ['GEMINI_API_SECRET'])
>>> r = g.ticker(symbol='ethusd').json()
{
  u'ask': u'298.00',
  u'volume': {
    u'timestamp': 1502351700000,
    u'ETH': u'3544.37638449',
    u'USD': u'534369.17025402'
  },
  u'bid': u'275.00', u'last': u'298.00'
}
```